### PR TITLE
Adds support for DRN/DRS

### DIFF
--- a/Messenger/Services/EurekaMonitor.cs
+++ b/Messenger/Services/EurekaMonitor.cs
@@ -78,7 +78,7 @@ public sealed unsafe class EurekaMonitor : IDisposable
     private void ClientState_TerritoryChanged(ushort obj)
     {
         Stop();
-        if(Svc.Data.GetExcelSheet<TerritoryType>().TryGetRow(obj, out var t) && t.GetTerritoryIntendedUse().EqualsAny(TerritoryIntendedUseEnum.Eureka, TerritoryIntendedUseEnum.Bozja, TerritoryIntendedUseEnum.Occult_Crescent))
+        if(Svc.Data.GetExcelSheet<TerritoryType>().TryGetRow(obj, out var t) && t.GetTerritoryIntendedUse().EqualsAny(TerritoryIntendedUseEnum.Eureka, TerritoryIntendedUseEnum.Bozja, TerritoryIntendedUseEnum.Large_Scale_Raid, TerritoryIntendedUseEnum.Large_Scale_Savage_Raid, TerritoryIntendedUseEnum.Occult_Crescent))
         {
             Start();
         }

--- a/Messenger/Utils.cs
+++ b/Messenger/Utils.cs
@@ -29,7 +29,7 @@ internal static unsafe partial class Utils
     public const uint EngagementID = 1000000;
     public const uint SuperchannelID = 1000001;
 
-    public static bool IsInForay() => Player.TerritoryIntendedUse.EqualsAny(TerritoryIntendedUseEnum.Eureka, TerritoryIntendedUseEnum.Bozja, TerritoryIntendedUseEnum.Occult_Crescent);
+    public static bool IsInForay() => Player.TerritoryIntendedUse.EqualsAny(TerritoryIntendedUseEnum.Eureka, TerritoryIntendedUseEnum.Bozja, TerritoryIntendedUseEnum.Large_Scale_Raid, TerritoryIntendedUseEnum.Large_Scale_Savage_Raid, TerritoryIntendedUseEnum.Occult_Crescent);
 
     public static string SendTellInForay(Sender destination, string message)
     {


### PR DESCRIPTION
`TerritoryIntendedUseEnum.Large_Scale_Raid` & `TerritoryIntendedUseEnum.Large_Scale_Savage_Raid` are only used with DRN & DRS so far. Tested in DRS.